### PR TITLE
Fix class cast exception

### DIFF
--- a/src/main/java/com/github/fge/avro/translators/RecordTranslator.java
+++ b/src/main/java/com/github/fge/avro/translators/RecordTranslator.java
@@ -109,7 +109,7 @@ final class RecordTranslator
     private static void injectDefault(final ObjectNode propertyNode,
         final Schema.Field field)
     {
-        final JsonNode value = (JsonNode) field.defaultVal();
+        final Object value = field.defaultVal();
         if (value == null)
             return;
 


### PR DESCRIPTION
defaultVal result can be of any type, not only JsonNode.